### PR TITLE
[ios] Allow view controller to present from non-navcontroller

### DIFF
--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -102,7 +102,6 @@ class ReactNavigation: NSObject {
   func present(_ screenName: String, withProps props: [String: AnyObject], options: [String: AnyObject], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     print("present \(screenName)")
     DispatchQueue.main.async {
-      guard let nav = self.coordinator.topNavigationController() else { return }
       guard let current = self.coordinator.topViewController() as? ReactViewController else {
         print("Called present() when topViewController() isn't a ReactViewController")
         return
@@ -125,7 +124,7 @@ class ReactNavigation: NSObject {
       }
 
       self.coordinator.registerFlow(presented, resolve: resolve, reject: reject)
-      nav.presentReactViewController(presented, animated: animated, completion: nil, presentationStyle: self.modalPresentationStyle(from: options), makeTransition: makeTransition)
+      current.presentReactViewController(presented, animated: animated, completion: nil, presentationStyle: self.modalPresentationStyle(from: options), makeTransition: makeTransition)
     }
   }
   


### PR DESCRIPTION
Currently, you can only `present()` from a nav controller, which is an unnecessary constraint. Let's do something about that.

(This is now consistent with Android's existing behaviour)