### PR TITLE
Toggle tab bar visibility on push/pop

### DIFF
--- a/docs/api/navigator/push.md
+++ b/docs/api/navigator/push.md
@@ -5,8 +5,8 @@
 1. `screenName` (`string`): The screen identifier of the screen to be pushed.
 2. `props` (`Object`): Props to be passed into the pushed screen.
 3. `options` (`Object`): Options for the navigation transition:
-  - `options.transitionGroup` (`string`): The shared element group ID to use for the shared element
-  transition
+  - `options.prefersBottomBarHidden` (`boolean`): Toggles visibility of bottom bar(/tab bar) when pushing/popping screens
+  - `options.transitionGroup` (`string`): The shared element group ID to use for the shared element transition
 
 ## Returns
 

--- a/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/MainFragment.java
+++ b/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/MainFragment.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.Toast;
 
+import com.airbnb.android.react.navigation.ReactNativeIntents;
 import com.airbnb.android.react.navigation.ReactNativeTabActivity;
 import com.airbnb.android.react.navigation.ScreenCoordinator;
 import com.airbnb.android.react.navigation.ScreenCoordinatorComponent;
@@ -38,7 +39,8 @@ public class MainFragment extends Fragment {
     btnScreen.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        getScreenCoordinator().presentScreen(NativeFragment.newInstance(1));
+//        ReactNativeIntents.pushScreen(getActivity(), "ScreenOne");
+        getScreenCoordinator().pushScreen("ScreenOne");
       }
     });
 
@@ -49,7 +51,7 @@ public class MainFragment extends Fragment {
     btnTabs.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        startActivity(new Intent(getContext(), ReactNativeTabActivity.class));
+        ReactNativeIntents.presentScreen(getActivity(), "TabScreen");
       }
     });
 

--- a/example/screens/NavigationExampleScreen.js
+++ b/example/screens/NavigationExampleScreen.js
@@ -37,8 +37,18 @@ export default class NavigationExampleScreen extends Component {
           onPress={() => Navigator.present('ScreenOne')}
         />
         <Row
-          title="Push new screen"
+          title="Push new screen (with tabs)"
           onPress={() => Navigator.push('ScreenOne')}
+        />
+        <Row
+          title="Push new screen (without tabs)"
+          onPress={() => Navigator.push(
+            'ScreenOne',
+            {},
+            {
+              prefersBottomBarHidden: true,
+            },
+          )}
         />
         <Row
           title="Pop"

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -67,6 +67,7 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
   private boolean isSharedElementTransition;
   private boolean isWaitingForRenderToFinish = false;
   private float barHeight;
+  private boolean prefersBottomBarHidden = false;
   private ReadableMap initialConfig = ConversionUtil.EMPTY_MAP;
   private ReadableMap previousConfig = ConversionUtil.EMPTY_MAP;
   private ReadableMap renderedConfig = ConversionUtil.EMPTY_MAP;
@@ -304,6 +305,12 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
   public void onResume() {
     super.onResume();
     Log.d(TAG, "onResume");
+
+    if (getActivity() instanceof ReactNativeTabActivity) {
+      ReactNativeTabActivity rnta = (ReactNativeTabActivity)getActivity();
+      rnta.toggleBottomNavigationHidden(prefersBottomBarHidden);
+    }
+
     updateBarHeightIfNeeded();
     emitEvent(ON_APPEAR, null);
   }
@@ -472,5 +479,13 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
           PermissionListener listener) {
     permissionListener = listener;
     requestPermissions(permissions, requestCode);
+  }
+
+  public boolean isPrefersBottomBarHidden() {
+    return prefersBottomBarHidden;
+  }
+
+  public void setPrefersBottomBarHidden(boolean prefersBottomBarHidden) {
+    this.prefersBottomBarHidden = prefersBottomBarHidden;
   }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeTabActivity.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeTabActivity.java
@@ -168,6 +168,10 @@ public class ReactNativeTabActivity extends ReactAwareActivity
     }
   }
 
+  public void toggleBottomNavigationHidden(boolean hidden) {
+    bottomNavigationView.setVisibility(hidden ? View.GONE : View.VISIBLE);
+  }
+
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     reactInstanceManager.onActivityResult(this, requestCode, resultCode, data);

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
@@ -36,6 +36,7 @@ public class ScreenCoordinator {
   private static final String TAG = ScreenCoordinator.class.getSimpleName();
   static final String EXTRA_PAYLOAD = "payload";
   private static final String TRANSITION_GROUP = "transitionGroup";
+  private static final String PREFERS_BOTTOM_BAR_HIDDEN = "prefersBottomBarHidden";
 
   enum PresentAnimation {
     Modal(R.anim.slide_up, R.anim.delay, R.anim.delay, R.anim.slide_down),
@@ -103,11 +104,17 @@ public class ScreenCoordinator {
     }
 
     if (ViewUtils.isAtLeastLollipop() && options != null && options.containsKey(TRANSITION_GROUP)) {
-        setupFragmentForSharedElement(currentFragment,  fragment, ft, options);
+      setupFragmentForSharedElement(currentFragment, fragment, ft, options);
     } else {
       PresentAnimation anim = PresentAnimation.Push;
       ft.setCustomAnimations(anim.enter, anim.exit, anim.popEnter, anim.popExit);
     }
+
+    if (fragment instanceof ReactNativeFragment) {
+      ReactNativeFragment rnf = (ReactNativeFragment) fragment;
+      rnf.setPrefersBottomBarHidden(options.getBoolean(PREFERS_BOTTOM_BAR_HIDDEN, false));
+    }
+
     BackStack bsi = getCurrentBackStack();
     ft
             .detach(currentFragment)

--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -80,6 +80,8 @@ class ReactNavigation: NSObject {
       let pushed = ReactViewController(moduleName: screenName, props: props)
       pushed.delegate = current.delegate
 
+      pushed.prefersBottomBarHidden = options["prefersBottomBarHidden"] as? Bool ?? false
+
       let animated = (options["animated"] as? Bool) ?? true
       var makeTransition: (() -> ReactSharedElementTransition)? = nil
 

--- a/lib/ios/native-navigation/ReactViewController.swift
+++ b/lib/ios/native-navigation/ReactViewController.swift
@@ -74,7 +74,7 @@ open class ReactViewController: UIViewController {
   var transition: ReactSharedElementTransition?
   var eagerNavigationController: UINavigationController?
   open var reactFlowId: String?
-  open var showTabBar: Bool = false // TODO(lmr): showTabBar? is this needed?
+  open var prefersBottomBarHidden: Bool = false
   open weak var delegate: ReactViewControllerDelegate?
   var dismissResultCode: ReactFlowResultCode?
   var dismissPayload: [String: AnyObject]?
@@ -214,6 +214,18 @@ open class ReactViewController: UIViewController {
     }
   }
 
+  final override public var hidesBottomBarWhenPushed: Bool {
+    get {
+      guard navigationController?.viewControllers.last == self else {
+        return false
+      }
+
+      return prefersBottomBarHidden
+    }
+    set {
+      super.hidesBottomBarWhenPushed = newValue
+    }
+  }
 
 
 


### PR DESCRIPTION
Introducing an option for `prefersBottomBarHidden` when pushing a screen, so that the tab bar can show/hide as necessary.

In pictures:

iOS:

![](http://hi.notjo.sh/1Z081I142R3C/Screen%20Recording%202017-10-25%20at%2005.04%20pm.gif)

Android:

![](http://hi.notjo.sh/1c0U1V471l0k/Screen%20Recording%202017-10-25%20at%2005.05%20pm.gif)

I think the Android implementation could use work (animating the transition), but I'm happy to leave that as an improvement for a later day.