### PR TITLE
Translucent navigation bar height

### DIFF
--- a/docs/api/navigator-config.md
+++ b/docs/api/navigator-config.md
@@ -130,7 +130,7 @@ Defaults to `'fade'`.
 
 #### `onEnterTransitionCompleted: () => void`
 
-#### `onBarHeightChanged: (height: number) => void`
+#### `onBarHeightChanged: ({ height: number, force: boolean }) => void`
 
 #### `onLeftPress: () => void`
 

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -25,8 +25,10 @@ import android.view.animation.Animation;
 import com.airbnb.android.R;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactRootView;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
 import com.facebook.react.modules.core.PermissionListener;
 
@@ -470,7 +472,11 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
     );
     if (newHeight != barHeight) {
       barHeight = newHeight;
-      emitEvent("onBarHeightChanged", barHeight);
+      WritableMap map = Arguments.createMap();
+      map.putDouble("height", barHeight);
+      map.putBoolean("force", false);
+
+      emitEvent("onBarHeightChanged", map);
     }
   }
 

--- a/lib/ios/native-navigation/ReactNavigationImplementation.swift
+++ b/lib/ios/native-navigation/ReactNavigationImplementation.swift
@@ -360,23 +360,11 @@ open class DefaultReactNavigationImplementation: ReactNavigationImplementation {
     navigationController: UINavigationController?,
     config: [String: AnyObject]
   ) -> CGFloat {
-    var statusBarHidden = false
-    var navBarHidden = false
-    var hasPrompt = false;
-    if let hidden = boolForKey("statusBarHidden", config) {
-      statusBarHidden = hidden
+    guard viewController.isViewLoaded else {
+      return 0
     }
-    if let hidden = boolForKey("hidden", config) {
-      navBarHidden = hidden
-    }
-    if stringForKey("prompt", config) != nil {
-      hasPrompt = true
-    }
-    if let navController = navigationController {
-      return navController.navigationBar.frame.height + (statusBarHidden ? 0 : 20)
-    }
-    // make a best guess based on config
-    return (statusBarHidden ? 0 : 20) + (navBarHidden ? 0 : 44) + (hasPrompt ? 30 : 0)
+
+    return viewController.topLayoutGuide.length
   }
 
   public func makeNavigationController(rootViewController: UIViewController) -> UINavigationController {

--- a/lib/ios/native-navigation/ReactViewController.swift
+++ b/lib/ios/native-navigation/ReactViewController.swift
@@ -182,7 +182,6 @@ open class ReactViewController: UIViewController {
 
   override open func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    updateBarHeightIfNeeded()
     emitEvent("onAppear", body: nil)
   }
 
@@ -212,6 +211,12 @@ open class ReactViewController: UIViewController {
         transition = nil
       }
     }
+  }
+
+  override open func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    updateBarHeightIfNeeded()
   }
 
   final override public var hidesBottomBarWhenPushed: Bool {
@@ -365,7 +370,6 @@ open class ReactViewController: UIViewController {
     prevConfig = renderedConfig
     renderedConfig = initialConfig.combineWith(values: props)
     reconcileScreenConfig()
-    updateBarHeightIfNeeded()
   }
 
   func updateBarHeightIfNeeded() {
@@ -376,7 +380,10 @@ open class ReactViewController: UIViewController {
     )
     if newHeight != barHeight {
       barHeight = newHeight
-      emitEvent("onBarHeightChanged", body: barHeight as AnyObject)
+      emitEvent("onBarHeightChanged", body: [
+        "height": barHeight,
+        "force": isCurrentlyTransitioning
+      ] as AnyObject)
     }
   }
 

--- a/lib/js/Spacer.js
+++ b/lib/js/Spacer.js
@@ -27,11 +27,11 @@ class Spacer extends React.Component {
     DeviceEventEmitter.removeSubscription(this.subscription);
   }
 
-  onHeightChanged(height) {
-    if (this.props.animated) {
+  onHeightChanged(value) {
+    if (this.props.animated && !value.force) {
       LayoutAnimation.easeInEaseOut();
     }
-    this.setState({ height });
+    this.setState({ height: value.height });
   }
 
   render() {


### PR DESCRIPTION
Using the `topLayoutGuide` on iOS gets us mostly what we want, instead of the previous effort of guessing the height.

It's not *always* available immediately (because the view hasn't loaded yet, etc etc) so I added a "force" parameter to the event, which should skip animations if we get an update during a nav transition.

/cc @skeie 