### PR TITLE
Revert "added postinstall script because frameworks vs headers"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "docs:build": "npm run docs:prepare && gitbook build",
     "docs:watch": "npm run docs:prepare && gitbook serve",
     "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git fetch https://github.com/airbnb/native-navigation.git gh-pages && git checkout -b gh-pages && git add . && git commit -am 'update book' && git push https://github.com/airbnb/native-navigation.git gh-pages --force",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "sed -i.backup 's/#import <RCTAnimation\\/RCTValueAnimatedNode.h>/#import \"RCTValueAnimatedNode.h\"/' ./node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h; sed -i.backup 's/#import <fishhook\\/fishhook.h>/#import \"fishhook.h\"/' ./node_modules/react-native/Libraries/WebSocket/RCTReconnectingWebSocket.m"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts taxfix/native-navigation#19

Because libraries aren't apps, and `postinstall` runs when we're included as a library. Will fix it betterer in another PR another day.