### PR TITLE
Fix startup freeze

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -142,19 +142,18 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
     if (!isSuccessfullyInitialized()) {
       // TODO(lmr): need a different way of doing this
       // TODO(lmr): move to utils
-      reactInstanceManager.addReactInstanceEventListener(
-              new ReactInstanceManager.ReactInstanceEventListener() {
-                @Override
-                public void onReactContextInitialized(ReactContext context) {
-                  reactInstanceManager.removeReactInstanceEventListener(this);
-                  handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                      onAttachWithReactContext();
-                    }
-                  });
-                }
-              });
+      reactNavigationCoordinator.addReactInstanceEventListener( new ReactInstanceManager.ReactInstanceEventListener() {
+        @Override
+        public void onReactContextInitialized(ReactContext context) {
+          reactNavigationCoordinator.removeReactInstanceEventListener(this);
+          handler.post(new Runnable() {
+            @Override
+            public void run() {
+              onAttachWithReactContext();
+            }
+          });
+        }
+      });
     } else {
       onAttachWithReactContext();
       // in this case, we end up waiting for the first render to complete

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNavigationCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNavigationCoordinator.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +69,12 @@ public class ReactNavigationCoordinator {
         public void onReactContextInitialized(ReactContext context) {
           reactInstanceManager.removeReactInstanceEventListener(this);
           isSuccessfullyInitialized = true;
+
+          List<ReactInstanceManager.ReactInstanceEventListener> listeners =
+              new ArrayList<>(ReactNavigationCoordinator.this.listeners);
+          for (ReactInstanceManager.ReactInstanceEventListener l: listeners) {
+            l.onReactContextInitialized(context);
+          }
         }
       });
   }
@@ -89,6 +96,15 @@ public class ReactNavigationCoordinator {
   public void injectExposedActivities(List<ReactExposedActivityParams> exposedActivities) {
     // TODO(lmr): would it make sense to warn or throw here if it's already set?
     this.exposedActivities = exposedActivities;
+  }
+
+  private List<ReactInstanceManager.ReactInstanceEventListener> listeners = new ArrayList<>();
+  public void addReactInstanceEventListener(ReactInstanceManager.ReactInstanceEventListener l) {
+    this.listeners.add(l);
+  }
+
+  public void removeReactInstanceEventListener(ReactInstanceManager.ReactInstanceEventListener l) {
+    this.listeners.remove(l);
   }
 
   /**


### PR DESCRIPTION
This will fix the startup freeze that happens like every third time.

ReactNativeFragment had it's own RN init callback that wasn't called sometimes because of a race condition. Now it uses the same callback as the ReactNavigationCoordinator, where the "real" initialisation "is happening".

😄 🔫 