### PR TITLE
Force navigation spacer height caching

### DIFF
--- a/example/components/Screen.js
+++ b/example/components/Screen.js
@@ -32,7 +32,7 @@ export default class Screen extends React.Component {
         title={title}
         backgroundColor={theme.color.lightGray}
         elevation={4}
-        prefersLargeTitles
+        prefersLargeTitles={false}
         onBackPress={() => console.log('onBackPress')}
         onLeftPress={() => console.log('onLeftPress')}
         onRightPress={x => console.log('onRightPress', x)}

--- a/lib/ios/native-navigation/ReactViewController.swift
+++ b/lib/ios/native-navigation/ReactViewController.swift
@@ -382,8 +382,13 @@ open class ReactViewController: UIViewController {
       barHeight = newHeight
       emitEvent("onBarHeightChanged", body: [
         "height": barHeight,
-        "force": isCurrentlyTransitioning
+        "force": isCurrentlyTransitioning || true // force it - we're not using animations currently?
       ] as AnyObject)
+
+      let newProps = propsWithMetadata(props, nativeNavigationInstanceId, barHeight)
+      if let rView = view as? RCTRootView {
+        rView.appProperties = newProps
+      }
     }
   }
 


### PR DESCRIPTION
⚠️ Okay, this is a pretty rough hack. But we want to force the component to cache the correct navigation bar height. And because of 🍝 that's not trivial. So, yolo.